### PR TITLE
Fix auth persistence on refresh

### DIFF
--- a/composables/useAuth.ts
+++ b/composables/useAuth.ts
@@ -1,104 +1,121 @@
 interface UserResponse {
-  id: number
-  username: string
-  email: string
-  first_name: string
-  last_name: string
-  date_joined: string
+  id: number;
+  username: string;
+  email: string;
+  first_name: string;
+  last_name: string;
+  date_joined: string;
 }
 
 interface AuthResponse {
-  message: string
-  user: UserResponse
+  message: string;
+  user: UserResponse;
 }
 
 interface AuthState {
-  token: string | null
-  user: UserResponse | null
-  error: string | null
+  token: string | null;
+  user: UserResponse | null;
+  error: string | null;
 }
 
 export const useAuth = () => {
+  const userCookie = useCookie<UserResponse | null>('user');
+
   // Use useState for persistent state across page reloads
   const state = useState<AuthState>('auth', () => ({
     token: null,
-    user: null,
-    error: null
-  }))
+    user: userCookie.value ?? null,
+    error: null,
+  }));
 
-  const router = useRouter()
-  const config = useRuntimeConfig()
+  const router = useRouter();
+  const config = useRuntimeConfig();
 
   // Computed properties for easier access
-  const token = computed(() => state.value.token)
-  const user = computed(() => state.value.user)
-  const error = computed(() => state.value.error)
-  const isAuthenticated = computed(() => !!state.value.user)
+  const token = computed(() => state.value.token);
+  const user = computed(() => state.value.user);
+  const error = computed(() => state.value.error);
+  const isAuthenticated = computed(() => !!state.value.user);
+
+  watch(
+    () => state.value.user,
+    (val) => {
+      userCookie.value = val;
+    }
+  );
 
   // Login function
   const login = async (username: string, password: string) => {
-    state.value.error = null
-    
+    state.value.error = null;
+
     try {
       const response = await $fetch<AuthResponse>('users/login/', {
         baseURL: config.public.apiBase,
         method: 'POST',
-        body: { username, password }
-      })
-      
-      state.value.user = response.user
+        body: { username, password },
+      });
+
+      state.value.user = response.user;
+      userCookie.value = response.user;
       // Store user info in localStorage for persistence
       if (process.client) {
-        localStorage.setItem('user', JSON.stringify(response.user))
+        localStorage.setItem('user', JSON.stringify(response.user));
       }
-      await router.push('/')
+      await router.push('/');
     } catch (err: any) {
-      state.value.error = err?.data?.message || 'Erro desconhecido'
-      console.error('Login error:', err)
+      state.value.error = err?.data?.message || 'Erro desconhecido';
+      console.error('Login error:', err);
     }
-  }
+  };
 
   // Logout function
   const logout = async () => {
     try {
       await useFetch('/users/logout/', {
         baseURL: config.public.apiBase,
-        method: 'POST'
-      })
+        method: 'POST',
+      });
     } catch (err) {
-      console.error('Logout error:', err)
+      console.error('Logout error:', err);
       // Continue with logout even if API call fails
     } finally {
-      state.value.token = null
-      state.value.user = null
-      state.value.error = null
-      
+      state.value.token = null;
+      state.value.user = null;
+      state.value.error = null;
+
+      userCookie.value = null;
+
       if (process.client) {
-        localStorage.removeItem('user')
+        localStorage.removeItem('user');
       }
-      
-      await router.push('/login')
+
+      await router.push('/login');
     }
-  }
+  };
 
   // Initialize auth state from localStorage
   const initAuth = () => {
+    if (userCookie.value) {
+      state.value.user = userCookie.value;
+    }
+
     if (process.client) {
-      const storedUser = localStorage.getItem('user')
+      const storedUser = localStorage.getItem('user');
       if (storedUser) {
         try {
-          state.value.user = JSON.parse(storedUser)
+          state.value.user = JSON.parse(storedUser);
+          userCookie.value = state.value.user;
         } catch (err) {
-          console.error('Error parsing stored user:', err)
-          localStorage.removeItem('user')
+          console.error('Error parsing stored user:', err);
+          localStorage.removeItem('user');
         }
       }
     }
-  }
+  };
 
   // Auto-initialize on client side
   if (process.client) {
-    initAuth()
+    initAuth();
   }
 
   return {
@@ -108,6 +125,6 @@ export const useAuth = () => {
     token,
     user,
     error,
-    isAuthenticated
-  }
-}
+    isAuthenticated,
+  };
+};


### PR DESCRIPTION
## Summary
- store logged-in user data in a cookie
- sync auth state with cookie and localStorage so middleware can see user on SSR

## Testing
- `npx prettier -w composables/useAuth.ts`
- `pnpm build` *(fails: Error when performing the request to https://registry.npmjs.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_68743ce6bb78832f89ba0c44ccb54782