### PR TITLE
Fix transaction modal and loading logic

### DIFF
--- a/composables/useTransactions.ts
+++ b/composables/useTransactions.ts
@@ -44,7 +44,12 @@ export const useTransactions = () => {
         params.append('transaction_type', apiFilters.transaction_type)
       }
 
-      const response = await $fetch<Transaction[]>(`/finance/transactions/?${params}`, {
+      const query = params.toString()
+      const url = query
+        ? `/finance/transactions/?${query}`
+        : '/finance/transactions/'
+
+      const response = await $fetch<Transaction[]>(url, {
         baseURL: config.public.apiBase,
         credentials: 'include'
       })

--- a/pages/transactions.vue
+++ b/pages/transactions.vue
@@ -411,6 +411,7 @@
 </template>
 
 <script setup lang="ts">
+import TransactionModal from '~/components/TransactionModal.vue'
 import {
   PlusIcon,
   DocumentTextIcon,


### PR DESCRIPTION
## Summary
- import `TransactionModal` explicitly
- fix transaction API URL construction to avoid trailing `?`

## Testing
- `pnpm build` *(fails: Error when performing the request to https://registry.npmjs.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_68744303b97c832fbf006a0995c92fa3